### PR TITLE
Processor Striping Fix

### DIFF
--- a/diablo_2.0/for/les.f
+++ b/diablo_2.0/for/les.f
@@ -1,8 +1,8 @@
       subroutine les_chan
 C This subroutine models the terms owing to the subgrid scale stress
 C if the computation is to be treated as an LES not a DNS
-C This subroutine should be called when the velocity is in fourier space 
-C in the periodic directions, on output, the velocity will be 
+C This subroutine should be called when the velocity is in fourier space
+C in the periodic directions, on output, the velocity will be
 C in physical space.
 C It is assumed that the test filter and the LES filter are performed
 C by the same operation
@@ -19,10 +19,10 @@ C if for the subgrid scalar dissipation
       real*8 EPS_SGS1_MEAN(0:NY+1)
       real*8 U3_bar(0:NY+1)
       real*8 U1_bar(0:NY+1)
- 
+
       real*8 C_SMAG
       parameter (C_SMAG=0.17d0)
-      real*8 DELTA_Y(0:NY+1),DELTA_YF(0:NY+1) 
+      real*8 DELTA_Y(0:NY+1),DELTA_YF(0:NY+1)
       real*8 alpha_sgs,beta_sgs
       real*8 denominator_sum
 
@@ -88,7 +88,7 @@ C Apply Boundary conditions to velocity field
         U1_bar(J)=DBLE(CU1(0,0,J))
         U3_bar(J)=DBLE(CU3(0,0,J))
       END DO
-      END IF 
+      END IF
       IF (USE_MPI) THEN
             CALL MPI_BCAST(U1_bar,NY+2,MPI_DOUBLE_PRECISION,0,
      &     MPI_COMM_Z,ierror)
@@ -104,9 +104,9 @@ C Apply Boundary conditions to velocity field
 ! Compute |S| at GYF points, store in S1
 ! Interpolation to GYF points is easy since by definition
 ! GYF points are exactly midway between neighboring GY points
-! Sij4 and Sij6 have the mean shear 
-! remove the zero value U1,3bar as in 
-! compute strain 
+! Sij4 and Sij6 have the mean shear
+! remove the zero value U1,3bar as in
+! compute strain
       DO J=JSTART,JEND
         DO K=0,NZP-1
           DO I=0,NXM
@@ -123,7 +123,7 @@ C Apply Boundary conditions to velocity field
 ! Optionally remove mean shear
      &                           -0.5d0*(U3_bar(J)-U3_bar(J-1))/DY(J)
      &                           -0.5d0*(U3_bar(J+1)-U3_bar(J))/DY(J+1)
-     &        ))**2.d0 
+     &        ))**2.d0
      &               +2.d0*Sij3(I,K,J)**2.d0 )
           END DO
         END DO
@@ -156,7 +156,7 @@ C Apply Boundary conditions to velocity field
       END DO
 
 ! Now, compute |S|*S_ij, storing in Sij
-! First compute at GYF points 
+! First compute at GYF points
       DO J=JSTART,JEND
         DO K=0,NZP-1
           DO I=0,NXM
@@ -265,7 +265,7 @@ C Apply Boundary conditions to velocity field
       else if ((LES_MODEL_TYPE.EQ.2).or.(LES_MODEL_TYPE.eq.3)) then
 ! Here, use a dynamic smagorinsky model with or without scale similar part
 
-      stop 'ERROR: LES_MODEL_TYPE=2, 3 not supported yet in MPI'  
+      stop 'ERROR: LES_MODEL_TYPE=2, 3 not supported yet in MPI'
 
       end if
 
@@ -283,7 +283,7 @@ C Apply Boundary conditions to velocity field
             CF3(I,K,J)=CF3(I,K,J)
      &                -CIKX(I)*CSij5(I,K,J)
      &                -(CSij6(I,K,J+1)-CSij6(I,K,J))/DYF(J)
-     &                -CIKZ(K)*CSij3(I,K,J)   
+     &                -CIKZ(K)*CSij3(I,K,J)
           END DO
         END DO
       END DO
@@ -376,7 +376,7 @@ C Apply Boundary conditions to velocity field
      &                -CIKZ(K)*CSij3(I,K,J)
           END DO
         END DO
-      END DO 
+      END DO
         CALL FFT_XZ_TO_PHYSICAL(CTEMP,TEMP,0,NY+1)
         do J=0,NY+1
           do I=0,NXM
@@ -453,7 +453,7 @@ C Apply Boundary conditions to velocity field
           end do
           end do
         end do
- 
+
       call mpi_allreduce(mpi_in_place,S1_mean,NY+2,MPI_DOUBLE_PRECISION,
      &     MPI_SUM,MPI_COMM_Z,ierror)
       call mpi_allreduce(mpi_in_place,NU_T_mean,NY+2
@@ -482,16 +482,16 @@ C Apply Boundary conditions to velocity field
       Diag=gyf(1:NY)
       call WriteStatH5(FNAME,gname,Diag)
 
-      gname='nu_sgs' 
+      gname='nu_sgs'
       Diag=NU_T_mean(1:NY)
-      call WriteStatH5(FNAME,gname,Diag)     
+      call WriteStatH5(FNAME,gname,Diag)
 
-      gname='eps_sgs1' 
+      gname='eps_sgs1'
       Diag=EPS_SGS1_MEAN(1:NY)
-      call WriteStatH5(FNAME,gname,Diag)     
-    
+      call WriteStatH5(FNAME,gname,Diag)
+
       END IF
- 
+
 #else
 ! Here we aren't using HDF5, so write to text file
       IF (RANKZ.EQ.0) THEN
@@ -528,15 +528,17 @@ C For use in the LES model in channel flow (2 periodic directions)
       include 'header_les'
 
       integer I,J,K,ij
-     
-      DO J=1,NY
+
+      DO J=1,NY+1
         DO K=0,TNKZ
           DO I=0,NXP-1
             CSij1(I,K,J)=CIKX(I)*CU1(I,K,J)
-            CSij2(I,K,J)=(CU2(I,K,J+1)-CU2(I,K,J))/DYF(j) 
-            CSij3(I,K,J)=CIKZ(K)*CU3(I,K,J)  
+            CSij3(I,K,J)=CIKZ(K)*CU3(I,K,J)
             CSij5(I,K,J)=0.5d0*(CIKZ(K)*CU1(I,K,J)
      &                  +CIKX(I)*CU3(I,K,J))
+            if (J /= Ny + 1) then
+              CSij2(I,K,J)=(CU2(I,K,J+1)-CU2(I,K,J))/DYF(j)
+            end if
           END DO
         END DO
       END DO
@@ -544,12 +546,15 @@ C For use in the LES model in channel flow (2 periodic directions)
         DO K=0,TNKZ
           DO I=0,NXP-1
             CSij4(I,K,J)=0.5d0*((CU1(I,K,J)-CU1(I,K,J-1))/DY(j)
-     &                          +CIKX(I)*CU2(I,K,J) ) 
+     &                          +CIKX(I)*CU2(I,K,J) )
             CSij6(I,K,J)=0.5d0*(CIKZ(K)*CU2(I,K,J)
      &                         +(CU3(I,K,J)-CU3(I,K,J-1))/DY(j) )
           END DO
         END DO
-      END DO  
+      END DO
+
+      ! Need to communicate down CSij2 to each j = Ny + 1
+      call ghost_CSij2_mpi
 
 
        CALL FFT_XZ_TO_PHYSICAL(CSij1,Sij1,0,NY+1)
@@ -564,7 +569,7 @@ C For use in the LES model in channel flow (2 periodic directions)
       RETURN
       END
 
- 
+
       subroutine les_filter_chan(A,jstart,jend)
 ! This subroutine applies the les filter to the input field
 ! The indices to the start and end of the array in the y-direction
@@ -591,7 +596,7 @@ C For use in the LES model in channel flow (2 periodic directions)
 !      W0=1.d0/2.d0
 !      W1=1.d0/4.d0
 !      W2=0.d0
-      Wm1_j=1.d0/4.d0  
+      Wm1_j=1.d0/4.d0
       W0_j=1.d0/2.d0
       W1_j=1.d0/4.d0
 ! The following is for the 5-point trapezoidal rule, alpha*beta=9
@@ -634,7 +639,7 @@ C For use in the LES model in channel flow (2 periodic directions)
       end do
       ip1(NXM)=0
       do i=0,NX-3
-        ip2(i)=i+2    
+        ip2(i)=i+2
       end do
       ip2(NX-2)=0
       ip2(NXM)=1
@@ -645,9 +650,9 @@ C For use in the LES model in channel flow (2 periodic directions)
             B(i,k,j)=Wm2*A(im2(i),k,j)+Wm1*A(im1(i),k,j)+W0*A(i,k,j)
      &         +W1*A(ip1(i),k,j)+W2*A(ip2(i),k,j)
           end do
-        end do  
+        end do
       end do
- 
+
 ! Apply filter in the z-diretion
 !      B=Wm2*CSHIFT(B,-2,2)+Wm1*CSHIFT(B,-1,2)+W0*B+W1*CSHIFT(B,1,2)
 !     &       +W2*CSHIFT(B,2,2)
@@ -667,7 +672,7 @@ C For use in the LES model in channel flow (2 periodic directions)
       end do
       kp1(NZM)=0
       do k=0,NZ-3
-        kp2(k)=k+2    
+        kp2(k)=k+2
       end do
       kp2(NZ-2)=0
       kp2(NZM)=1
@@ -678,7 +683,7 @@ C For use in the LES model in channel flow (2 periodic directions)
             A(i,k,j)=Wm2*B(i,km2(k),j)+Wm1*B(i,km1(k),j)+W0*B(i,k,j)
      &         +W1*B(i,kp1(k),j)+W2*B(i,kp2(k),j)
           end do
-        end do  
+        end do
       end do
 
 ! Apply filter in the vertical direction at all physical cells
@@ -691,7 +696,7 @@ C For use in the LES model in channel flow (2 periodic directions)
 !       do j=jstart+1,jend-1
 !         do k=0,NZM
 !           do i=0,NXM
-!             B(i,k,j)=Wm1_j*B(i,k,j-1)+W0_j*B(i,k,j)+W1_j*B(i,k,j+1)  
+!             B(i,k,j)=Wm1_j*B(i,k,j-1)+W0_j*B(i,k,j)+W1_j*B(i,k,j+1)
 !           end do
 !         end do
 !       end do
@@ -722,7 +727,7 @@ C For use in the LES model in channel flow (2 periodic directions)
       real*8 PI, LX, LZ
       integer NKX,NKZ,TNKZ
 
-      real*8 KX(0:NX/3),KZ(0:2*(NZ/3))  
+      real*8 KX(0:NX/3),KZ(0:2*(NZ/3))
 
       real*8 A(0:NX+1,0:NZ+1,0:NY+1)
 
@@ -744,7 +749,7 @@ C For use in the LES model in channel flow (2 periodic directions)
 
       LX=PI
       LZ=2.d0*PI
-   
+
 ! Get the wavenumber vectors:
         NKX=NX/3
         DO I=0,NKX
@@ -766,7 +771,7 @@ C For use in the LES model in channel flow (2 periodic directions)
              B(i,k,j)=A(i,k,j)
            end do
          enddo
-       end do 
+       end do
 
 
 ! Convert to fourier space
@@ -787,13 +792,13 @@ C For use in the LES model in channel flow (2 periodic directions)
 ! Now, convert back to physical space
       call fft_xz_to_physical(CB,B,jstart,jend)
 
-       do j=jstart,jend 
+       do j=jstart,jend
          do k=0,NZM
            do i=0,NXM
              A(i,k,j)=B(i,k,j)
            end do
          end do
-       end do 
+       end do
 
       return
       end
@@ -831,7 +836,7 @@ C For use in the LES model in channel flow (2 periodic directions)
 
       IF (U_BC_YMIN.eq.1) THEN
         IF ((RANKY.eq.0).or.(.NOT.USE_MPI)) THEN
-! We are on a process at the bottom wall          
+! We are on a process at the bottom wall
          DO K=0,TNKZ
            DO I=0,NXP-1
              CU1(I,K,1)=CU1(I,K,2)
@@ -843,7 +848,7 @@ C For use in the LES model in channel flow (2 periodic directions)
 
       IF (W_BC_YMIN.eq.1) THEN
         IF ((RANKY.eq.0).or.(.NOT.USE_MPI)) THEN
-! We are on a process at the bottom wall          
+! We are on a process at the bottom wall
          DO K=0,TNKZ
            DO I=0,NXP-1
              CU3(I,K,1)=CU3(I,K,2)
@@ -855,7 +860,3 @@ C For use in the LES model in channel flow (2 periodic directions)
 
       RETURN
       END
-
-
-
-

--- a/diablo_2.0/for/save_stats.f
+++ b/diablo_2.0/for/save_stats.f
@@ -10,16 +10,16 @@ C----*|--.---------.---------.---------.---------.---------.---------.-|-------|
       LOGICAL FINAL
       integer i,j,k,n
       real*8 uc, ubulk
-    
+
 ! This variable is used to add up scalar diagnostics
       real*8 thsum(0:NY+1)
-! These variables are used to store and write 2D slices 
+! These variables are used to store and write 2D slices
       real*8 varxy(0:NXM,1:NY),varzy(0:NZP-1,1:NY),varxz(0:NXM,0:NZP-1)
 
 ! These variable are used for HDF5 writing
       real*8 Diag(1:NY)
 
-      IF (RANK.EQ.0) 
+      IF (RANK.EQ.0)
      &     WRITE(6,*) 'Saving flow statistics.'
 
       IF (USE_MPI) THEN
@@ -94,12 +94,12 @@ C Apply Boundary conditions to velocity field
       IF (NPROCY.EQ.1) THEN
       if (int(float(NY)/2.) .eq. float(NY)/2.) then
 ! IF NY is even
-        uc=dble(CU1(0,0,int(float(NY)/2.))) 
+        uc=dble(CU1(0,0,int(float(NY)/2.)))
       else
         uc=0.5*(dble(CU1(0,0,int(float(NY)/2.)-1))
      +         +dble(CU1(0,0,int(float(NY)/2.))))
       end if
-      write(*,*) 'Centerline velocity = ', uc 
+      write(*,*) 'Centerline velocity = ', uc
 ! Compute and write out bulk velocity
       END IF
 
@@ -146,7 +146,7 @@ C Apply Boundary conditions to velocity field
       IF (RANKZ.EQ.0) THEN
          ume=dble(CU1(0,0,:))
          vme=dble(CU2(0,0,:))
-         wme=dble(CU3(0,0,:)) 
+         wme=dble(CU3(0,0,:))
          DO n=1,N_TH
             thme(:,n)=dble(CTH(0,0,:,n))
          END DO
@@ -169,13 +169,13 @@ C Apply Boundary conditions to velocity field
       call tkebudget_chan
       IF (LES) call tkebudget_chan_les
 
-! Get the turbulent kinetic energy at each level 
+! Get the turbulent kinetic energy at each level
       do j=1,NY
         urms(j)=0.
         vrms(j)=0.
         wrms(j)=0.
       do k=0,NZP-1
-      do i=0,NXM 
+      do i=0,NXM
         urms(j)=urms(j)+(U1(i,k,j)-ume(j))**2.
         vrms(j)=vrms(j)+0.5*((U2(i,k,j  )-vme(j  ))**2. +
      &                       (U2(i,k,j+1)-vme(j+1))**2. )
@@ -195,7 +195,7 @@ C Apply Boundary conditions to velocity field
         urms(j)=sqrt(urms(j)/(float(NZ)*float(NX)))
         vrms(j)=sqrt(vrms(j)/(float(NZ)*float(NX)))
         wrms(j)=sqrt(wrms(j)/(float(NZ)*float(NX)))
-      end do 
+      end do
 
       ! Get the bulk rms value
       CALL INTEGRATE_Y_VAR(urms,urms_b,MPI_COMM_Y)
@@ -206,7 +206,7 @@ C Apply Boundary conditions to velocity field
 ! Here, uv and wv are defined on the GY grid
 ! uv is defined on the GYF grid
       do j=1,NY
-        uv(j)=0. 
+        uv(j)=0.
         uw(j)=0.
         wv(j)=0.
       do k=0,NZP-1
@@ -231,13 +231,13 @@ C Apply Boundary conditions to velocity field
      &     MPI_SUM,MPI_COMM_Z,ierror)
       call mpi_allreduce(mpi_in_place,wv,NY+2,MPI_DOUBLE_PRECISION,
      &     MPI_SUM,MPI_COMM_Z,ierror)
-      
+
       do j=1,NY
         uv(j)=uv(j)/(float(NZ)*float(NX))
         uw(j)=uw(j)/(float(NZ)*float(NX))
         wv(j)=wv(j)/(float(NZ)*float(NX))
       end do
-              
+
 ! Get the y-derivative of the mean velocity at GY points
       do j=1,NY
         dudy(j)=(ume(j)-ume(j-1))/(GYF(j)-GYF(j-1))
@@ -355,13 +355,13 @@ C Apply Boundary conditions to velocity field
       IF (RANKZ.eq.0) then
 
       gname='gyf'
-      Diag=gyf(1:NY)      
+      Diag=gyf(1:NY)
       call WriteStatH5(FNAME,gname,Diag)
 
       gname='ume'
       Diag=ume(1:NY)
       call WriteStatH5(FNAME,gname,Diag)
-    
+
       gname='vme'
       Diag=vme(1:NY)
       call WriteStatH5(FNAME,gname,Diag)
@@ -535,7 +535,7 @@ C Apply Boundary conditions to velocity field
         pe_diss(j,n)=thsum(j)/dble(NX*NZ)
       end do
 
-#ifdef HDF5 
+#ifdef HDF5
       if (MOVIE) then
          FNAME='movie.h5'
       if (n.eq.1) then
@@ -623,13 +623,13 @@ C Apply Boundary conditions to velocity field
 
 
 #ifdef HDF5
- 
-      FNAME='mean.h5' 
-  
+
+      FNAME='mean.h5'
+
       IF (RANKZ.eq.0) THEN
- 
+
       do n=1,N_TH
- 
+
         Diag=thme(1:NY,n)
         gname='thme'
      &           //CHAR(MOD(N,100)/10+48)
@@ -659,7 +659,7 @@ C Apply Boundary conditions to velocity field
      &           //CHAR(MOD(N,100)/10+48)
      &           //CHAR(MOD(N,10)+48)
         call WriteStatH5(FNAME,gname,Diag)
- 
+
       end do
 
       END IF
@@ -676,7 +676,7 @@ C Apply Boundary conditions to velocity field
       open(41,file=FNAME,form='formatted',status='unknown')
       write(41,*) TIME_STEP,TIME,DELTA_T
       write(41,*) UBULK
-      do n=1,N_TH 
+      do n=1,N_TH
       do j=1,NY
         write(41,402) j,GYF(J),thme(j,n)
      +      ,dthdy(j,n),thrms(j,n),thv(j,n),pe_diss(j,n)
@@ -686,10 +686,10 @@ C Apply Boundary conditions to velocity field
 402   format(I3,' ',6(F30.20,' '))
 #endif
 
-      IF (RANK.EQ.0) 
+      IF (RANK.EQ.0)
      &     write(*,*) 'VERBOSITY: ',VERBOSITY
-      if (VERBOSITY.gt.4) then 
-      IF (RANK.EQ.0) 
+      if (VERBOSITY.gt.4) then
+      IF (RANK.EQ.0)
      &        write(*,*) 'Outputting info for gnuplot...'
       open (unit=10, file="solution")
       do i=2,NXM
@@ -699,7 +699,7 @@ C Apply Boundary conditions to velocity field
         write (10,*) ""
       end do
       close (10)
-      call system ('gnuplot <gnuplot.in') 
+      call system ('gnuplot <gnuplot.in')
       end if
 
 #ifdef HDF5
@@ -783,7 +783,7 @@ C Apply Boundary conditions to velocity field
             end do
             GNAME='v_xz'
             call writeHDF5_xzplane(FNAME,GNAME,varxz)
-         END IF 
+         END IF
 
          if (USE_MPI) then
          call mpi_barrier(MPI_COMM_WORLD,ierror)
@@ -809,10 +809,10 @@ C Apply Boundary conditions to velocity field
             end do
             end do
             GNAME='nu_t_xz'
-            call writeHDF5_xzplane(FNAME,GNAME,varxz) 
+            call writeHDF5_xzplane(FNAME,GNAME,varxz)
          end if
          END IF
-         
+
          if (USE_MPI) then
          call mpi_barrier(MPI_COMM_WORLD,ierror)
          end if
@@ -874,8 +874,8 @@ C Convert velocity back to Fourier space
 ! END IF FINAL
       end if
 
-      IF (RANK.EQ.0) 
-     &     write(*,*) 'done save_stats chan' 
+      IF (RANK.EQ.0)
+     &     write(*,*) 'done save_stats chan'
 
       if (USE_MPI) then
       call mpi_barrier(MPI_COMM_WORLD,ierror)
@@ -885,7 +885,7 @@ C Convert velocity back to Fourier space
       END
 
       subroutine tkebudget_chan_les
-! Calculate the componet of th SGS dissipation rate 
+! Calculate the componet of th SGS dissipation rate
 ! only includes the terms timestepped implicitly
       include 'header'
       include 'header_les'
@@ -917,7 +917,7 @@ C Convert velocity back to Fourier space
           END DO
         END DO
       END DO
- 
+
 ! Now calculate the horizontal average
         do j=1,NY
           epsilon_sgs(j)=0.d0
@@ -930,7 +930,7 @@ C Convert velocity back to Fourier space
 
       call mpi_allreduce(mpi_in_place,epsilon_sgs,NY+2
      &    ,MPI_DOUBLE_PRECISION,
-     &     MPI_SUM,MPI_COMM_Z,ierror)        
+     &     MPI_SUM,MPI_COMM_Z,ierror)
 
 
 #ifdef HDF5
@@ -1083,7 +1083,7 @@ C Convert velocity back to Fourier space
       do j=2,NYM
       do k=0,NZP-1
       do i=0,NXM
-       S1(i,k,j)=((U2(i,k,j+1)-vme(j))
+       S1(i,k,j)=((U2(i,k,j+1)-vme(j+1))
      &        -(U2(i,k,j-1)-vme(j-1)))
      &            /(GY(j+1)-GY(j-1))
       end do
@@ -1172,7 +1172,7 @@ C Convert velocity back to Fourier space
         Diag=gyf(1:NY)
         call WriteStatH5(FNAME,gname,Diag)
 
-        gname='epsilon' 
+        gname='epsilon'
         Diag=epsilon(1:NY)
         call WriteStatH5(FNAME,gname,Diag)
       END IF
@@ -1234,8 +1234,5 @@ C Convert velocity back to Fourier space
       end if
 #endif
 
-      return 
+      return
       end
-
-
-

--- a/diablo_2.0/for/user_rhs.f
+++ b/diablo_2.0/for/user_rhs.f
@@ -1,9 +1,9 @@
        SUBROUTINE USER_RHS_CHAN_PHYSICAL
        include 'header'
 ! Here, you can add terms to the right hand side
-! of the momentum and scalar equations.  
+! of the momentum and scalar equations.
 ! The right hand side forcing arrays, CF2, CF2, CF3, CFTH
-! are in Fourier space.  The velocity and scalars are available 
+! are in Fourier space.  The velocity and scalars are available
 ! in physical space.
 ! S1 is available as a working variable
 
@@ -13,16 +13,16 @@
 
 !       CALL SLIP_VEL
 
-      RETURN 
+      RETURN
       END
 
 
        SUBROUTINE USER_RHS_CHAN_FOURIER
        include 'header'
 ! Here, you can add terms to the right hand side
-! of the momentum and scalar equations.  
+! of the momentum and scalar equations.
 ! The right hand side forcing arrays, CF2, CF2, CF3, CFTH
-! are in Fourier space.  The velocity and scalars are available 
+! are in Fourier space.  The velocity and scalars are available
 ! in Fourier space.
 ! S1 is available as a working variable
 
@@ -83,34 +83,6 @@
 ! End do N_TH
       END DO
 
-      do j=2,NY
-      do k=0,TNKZ
-      do i=0,NXP-1
-        CF2(I,K,J)=CF2(I,K,J)
-     &            -(DRHODX(N)*RI(N)*GY(J)/I_RO)
-     &                     *CIKZ(K)*CU2(I,K,J)
-     &            -(-1.d0*DRHODZ(N)*RI(N)*GY(J)/I_RO)
-     &                     *CIKX(I)*CU2(I,K,J)
-      end do
-      end do
-      end do
-
-! Add advection by thermal wind to the scalar equations
-      DO J=JSTART_TH(N),JEND_TH(N)
-        DO K=0,TNKZ
-          DO I=0,NXP-1
-            CFTH(I,K,J,N)=CFTH(I,K,J,N)
-     &     -(RI(N)/I_RO)*DRHODX(N)*GYF(J)
-     &                 *CIKZ(K)*CTH(I,K,J,N)
-     &     -(RI(N)/I_RO)*-1.d0*DRHODZ(N)*GYF(J)
-     &                 *CIKX(I)*CTH(I,K,J,N)
-          END DO
-        END DO
-      END DO
-
-! End do N_TH
-      END DO
-
       END IF
 
 ! Add sponge layer forcing
@@ -119,7 +91,7 @@
       END DO
       CALL SPONGE_VEL
 
-      RETURN 
+      RETURN
       END
 
 
@@ -204,7 +176,7 @@ C Note, that each cell has the same volume, so we can just average over all poin
       SUBROUTINE USER_RHS_CAVITY_PHYSICAL
       include 'header'
       RETURN
-      END 
+      END
 
 
       SUBROUTINE SPONGE_TH(N)
@@ -241,7 +213,7 @@ C Note, that each cell has the same volume, so we can just average over all poin
 ! Set the profile for relaxing the mean TH
       DO J=0,NY+1
         TH_0(J)=TH_BC_YMIN_C1(N)*GYF(J)
-      END DO       
+      END DO
 
 ! For MLI latmix
       if (n.eq.1) then
@@ -275,11 +247,10 @@ C Note, that each cell has the same volume, so we can just average over all poin
           CFTH(0,0,j,n)=CFTH(0,0,j,n)-SPONGE_SIGMA(j)
      &          *(CTH(0,0,j,n)-TH_0(J))
         end do
-      end if
 
       return
       end
-  
+
       SUBROUTINE SPONGE_VEL
 ! This subroutine applies a sponge relaxation (Rayleigh damping) towards a
 ! specified background state
@@ -322,7 +293,7 @@ C Note, that each cell has the same volume, so we can just average over all poin
         U2_0(j)=0.d0
       end do
 
-! Add damping function to explicit R-K 
+! Add damping function to explicit R-K
        do k=0,TNKZ
          do i=0,NXP-1
            if ((RANKZ.ne.0).or.(i.ne.0).or.(k.ne.0)) then
@@ -334,7 +305,7 @@ C Note, that each cell has the same volume, so we can just average over all poin
              CF2(I,K,J)=CF2(I,K,J)-
      &        0.5*(SPONGE_SIGMA(j)+SPONGE_SIGMA(j+1))*(CU2(i,k,j)-0.d0)
            end do
-           end if   
+           end if
          end do
       end do
 ! Damp mean flow
@@ -356,9 +327,9 @@ C Note, that each cell has the same volume, so we can just average over all poin
       include 'header'
       integer i,j,k,n,J1_TH(1:N_TH),J2_TH(1:N_TH)
       real*8 W_S(0:NY+1,1:N_TH)
-   
+
 ! Set indices corresponding to start and end of GYF grid
-      do n=1,N_TH 
+      do n=1,N_TH
       IF (RANKY.eq.NPROCY-1) then
 ! We are at the upper wall
             J1_TH(n)=JSTART_TH(n)
@@ -412,7 +383,7 @@ C Note, that each cell has the same volume, so we can just average over all poin
 !              S1(I,K,J)=(W_S(J+1,N)*TH(I,K,J,N)
 !     &               -W_S(J,N)*(TH(I,K,J,N)+TH(I,K,J-1,N))/2.d0)
 !     &                 /(GYF(j)-GY(j))
-! First order upwinding 
+! First order upwinding
               S1(I,K,J)=(W_S(J+1,N)*TH(I,K,J,N)
      &               -W_S(J,N)*TH(I,K,J-1,N))
      &                 /(GYF(j)-GYF(j-1))
@@ -432,78 +403,5 @@ C Note, that each cell has the same volume, so we can just average over all poin
         END DO
       end do
 
-      RETURN 
+      RETURN
       END
- 
-  
-      SUBROUTINE SPONGE_VEL
-! This subroutine applies a sponge relaxation (Rayleigh damping) towards a
-! specified background state
-! The intention is to allow an open boundary
-      include 'header'
-      integer i,j,k
-
-      real*8 L_sponge,L_bottom
-      real*8 SPONGE_AMP
-
-! The following variables will store the background state
-      real*8 U1_0(-1:NY+1), U2_0(0:NY+1), U3_0(-1:NY+1)
-
-! This variable will hold the forcing rate
-      real*8 SPONGE_SIGMA(0:NY+1)
-
-! Set the amplitude of the sponge
-      SPONGE_AMP=0.0001d0
-! Set the top of the sponge layer in physical units
-      L_sponge=-120.d0
-! Set the bottom of the computational domain in physical units
-      L_bottom=-140.d0
-        DO J=0,NY+1
-! Quadratic damping at lower wall
-         if (GYF(J).lt.L_sponge) then
-           SPONGE_SIGMA(j)=SPONGE_AMP*((L_sponge-GYF(J))
-     &       /(L_sponge-L_bottom))**2.d0
-         else
-           SPONGE_SIGMA(j)=0.d0
-         end if
-        END DO
-
-! Set the background state
-! Here, set the background to be geostrophic, with a linear temperature profile
-      do j=0,NY+1
-        U1_0(j)=0.d0
-        U3_0(j)=0.d0
-      end do
-      do j=0,NY+1
-        U2_0(j)=0.d0
-      end do
-
-! Add damping function to explicit R-K 
-       do k=0,TNKZ
-         do i=0,NKX
-           if ((i.ne.0).or.(k.ne.0)) then
-           do j=jstart,jend
-             CF1(I,K,J)=CF1(I,K,J)-SPONGE_SIGMA(j)*(CU1(i,k,j)-0.d0)
-             CF3(I,K,J)=CF3(I,K,J)-SPONGE_SIGMA(j)*(CU3(i,k,j)-0.d0)
-           end do
-           do j=1,NY
-             CF2(I,K,J)=CF2(I,K,J)-
-     &        0.5*(SPONGE_SIGMA(j)+SPONGE_SIGMA(j+1))*(CU2(i,k,j)-0.d0)
-           end do
-           end if   
-         end do
-      end do
-! Damp mean flow
-      do j=jstart,jend
-        CF1(0,0,j)=CF1(0,0,j)-SPONGE_SIGMA(j)*(CU1(0,0,j)-U1_0(j))
-        CF3(0,0,j)=CF3(0,0,j)-SPONGE_SIGMA(j)*(CU3(0,0,j)-U3_0(j))
-      end do
-      do j=1,NY
-        CF2(0,0,j)=CF2(0,0,j)-SPONGE_SIGMA(j)*(CU2(0,0,j)-U2_0(j))
-      end do
-
-      return
-      end
-
-
-


### PR DESCRIPTION
Fixes a number of issues contributing to mpi striping -- both diagnostic in saving stats, and with the subgrid model.

1. ume(j-1) mismatch when subtracting background strain.
2. dyf(Nyp+1) is now communicated down to be consistent across processes, rather than locally extrapolating.
3. CSij2 was not defined on Nyp+1 which is needed for computing temp in the sgs model, requiring some communicating down processors again.